### PR TITLE
fix: Fix memory leak issue in DisplayInfo::all() [Linux]

### DIFF
--- a/src/bin/memory_leak_test.rs
+++ b/src/bin/memory_leak_test.rs
@@ -1,0 +1,7 @@
+use display_info::DisplayInfo;
+
+fn main() {
+  loop {
+    DisplayInfo::all();
+  }
+}

--- a/src/bin/memory_leak_test.rs
+++ b/src/bin/memory_leak_test.rs
@@ -1,7 +1,0 @@
-use display_info::DisplayInfo;
-
-fn main() {
-  loop {
-    DisplayInfo::all();
-  }
-}

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,19 +1,21 @@
-use crate::DisplayInfo;
 use std::{
   ffi::{CStr, CString},
   os::raw::c_char,
   ptr, slice,
 };
+
 use x11::{
   xlib::{
     Display, XCloseDisplay, XDefaultRootWindow, XOpenDisplay, XResourceManagerString,
     XrmDestroyDatabase, XrmGetResource, XrmGetStringDatabase, XrmValue,
   },
   xrandr::{
-    XRRFreeCrtcInfo, XRRFreeScreenResources, XRRGetCrtcInfo, XRRGetOutputInfo, XRRGetOutputPrimary,
-    XRRGetScreenResourcesCurrent,
+    XRRFreeCrtcInfo, XRRFreeOutputInfo, XRRFreeScreenResources, XRRGetCrtcInfo, XRRGetOutputInfo,
+    XRRGetOutputPrimary, XRRGetScreenResourcesCurrent,
   },
 };
+
+use crate::DisplayInfo;
 
 fn get_xft_dpi(display_ptr: *mut Display) -> f32 {
   unsafe {
@@ -100,12 +102,14 @@ pub fn get_all() -> Vec<DisplayInfo> {
       let output_info = *output_info_ptr;
 
       if output_info.connection != 0 {
+        XRRFreeOutputInfo(output_info_ptr);
         continue;
       }
 
       let crtc_info_ptr = XRRGetCrtcInfo(display_ptr, screen_resources_ptr, output_info.crtc);
 
       if crtc_info_ptr.is_null() {
+        XRRFreeOutputInfo(output_info_ptr);
         continue;
       }
 
@@ -129,6 +133,7 @@ pub fn get_all() -> Vec<DisplayInfo> {
         is_primary: primary_output == *output,
       };
 
+      XRRFreeOutputInfo(output_info_ptr);
       XRRFreeCrtcInfo(crtc_info_ptr);
 
       display_infos.push(display_info);

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,3 +1,4 @@
+use crate::DisplayInfo;
 use std::{
   ffi::{CStr, CString},
   os::raw::c_char,
@@ -14,8 +15,6 @@ use x11::{
     XRRGetOutputPrimary, XRRGetScreenResourcesCurrent,
   },
 };
-
-use crate::DisplayInfo;
 
 fn get_xft_dpi(display_ptr: *mut Display) -> f32 {
   unsafe {


### PR DESCRIPTION
A pointer was not being freed when exiting from the loop iteration.
By freeing it on every path, it seems to have solved the issue.
Memory usage does not increase with time anymore.

[1-minute video explaining the changes](https://www.dropbox.com/s/egugd3fg5ztjptt/memory_leak_pull_request.mp4?dl=0)

Linked to [this issue](https://github.com/nashaofu/display-info/issues/3)