### PR TITLE
Change from sfhash to fxhash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1.0.68"
 core-graphics = "0.22.3"
 
 [target.'cfg(target_os="windows")'.dependencies]
-sfhash = "0.1.1"
+fxhash = "0.2.1"
 widestring = "1.0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies.windows]

--- a/src/win32.rs
+++ b/src/win32.rs
@@ -1,6 +1,5 @@
 use crate::DisplayInfo;
 use anyhow::{anyhow, Result};
-use sfhash::digest;
 use std::{mem, ops::Deref, ptr};
 use widestring::U16CString;
 use windows::{
@@ -46,8 +45,10 @@ impl DisplayInfo {
     let rc_monitor = monitor_info_exw.monitorInfo.rcMonitor;
     let dw_flags = monitor_info_exw.monitorInfo.dwFlags;
 
+    let id = fxhash::hash32(sz_device_string.as_bytes());
+
     DisplayInfo {
-      id: digest(sz_device_string.as_bytes()),
+      id,
       x: rc_monitor.left,
       y: rc_monitor.top,
       width: (rc_monitor.right - rc_monitor.left) as u32,


### PR DESCRIPTION
Changed from sfhash to fxhash because of license issue.

sfhash has LGPL license which conflicts with the Apache-2.0 license in the screenshot.rs library. 

I ran some tests and I could not see any difference in performance.