### PR TITLE
Monitor name for some platforms (X11, Wayland and Windows)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ fn main() {
 ## DisplayInfo struct
 
 -   `id` u32 - Unique identifier associated with the display.
+-   `name` String - The name of the display
 -   `raw_handle` CGDisplay/HMONITOR/Output - Native display raw handle
 -   `x` i32 - The display x coordinate.
 -   `y` i32 - The display y coordinate.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,10 @@ use windows::{get_all, get_from_point, ScreenRawHandle};
 
 use anyhow::Result;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct DisplayInfo {
+    /// The Display Name
+    pub name: Option<String>,
     /// Unique identifier associated with the display.
     pub id: u32,
     /// Native screen raw handle
@@ -65,5 +67,16 @@ impl DisplayInfo {
 
     pub fn from_point(x: i32, y: i32) -> Result<DisplayInfo> {
         get_from_point(x, y)
+    }
+
+    pub fn from_name(name: impl ToString) -> Result<DisplayInfo> {
+        let name = name.to_string();
+        let display_infos = get_all()?;
+
+        display_infos
+            .iter()
+            .find(|&d| d.name.as_deref().is_some_and(|n| n == name))
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("Get display info failed"))
     }
 }

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -28,6 +28,7 @@ impl From<&OutputInfo> for DisplayInfo {
         let (w, h) = info.logical_size.unwrap_or(info.physical_size);
         DisplayInfo {
             id: info.id,
+            name: info.name.clone(),
             raw_handle: unsafe { xcb::randr::Output::new(info.id) },
             x: ((x as f32) / scale_factor) as i32,
             y: ((y as f32) / scale_factor) as i32,
@@ -125,12 +126,12 @@ pub fn get_from_point(x: i32, y: i32) -> Result<DisplayInfo> {
 
     display_infos
         .iter()
-        .find(|&&d| {
+        .find(|&d| {
             x >= d.x
                 && x - (d.width as i32) < d.x + d.width as i32
                 && y >= d.y
                 && y - (d.height as i32) < d.y + d.height as i32
         })
-        .copied()
+        .cloned()
         .ok_or_else(|| anyhow!("Get display info failed"))
 }

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -23,7 +23,7 @@ impl DisplayInfo {
 
         DisplayInfo {
             id,
-            name: None,
+            name: Some(format!("Display {id}")),
             raw_handle: cg_display,
             x: origin.x as i32,
             y: origin.y as i32,

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -23,6 +23,7 @@ impl DisplayInfo {
 
         DisplayInfo {
             id,
+            name: None,
             raw_handle: cg_display,
             x: origin.x as i32,
             y: origin.y as i32,

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -53,7 +53,7 @@ impl DisplayInfo {
 
         DisplayInfo {
             id: hash32(sz_device_string.as_bytes()),
-            name: sz_device_string.to_string().ok(),
+            name: Some(sz_device_string.to_string()),
             raw_handle: h_monitor,
             x: rc_monitor.left,
             y: rc_monitor.top,

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -53,6 +53,7 @@ impl DisplayInfo {
 
         DisplayInfo {
             id: hash32(sz_device_string.as_bytes()),
+            name: sz_device_string.to_string().ok(),
             raw_handle: h_monitor,
             x: rc_monitor.left,
             y: rc_monitor.top,


### PR DESCRIPTION
This PR contains what is necessary for the `DislpayInfo` structure to provide also the name of the monitors that are obtained.

At the moment I did not find how to get the display name in mac, so this implementation is pending.

> [!NOTE]
> The cost of this implementation is to lose the `Copy` that the `DisplayInfo` structure had.

The decision to implement the `from_name` function in the `DisplayInfo` implementation was because it is not a function that requires a different implementation per platform, so a generic function for everyone was sufficient.