### PR TITLE
fix: scale factor in windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ widestring = "1.0"
 windows = { version = "0.52", features = [
     "Win32_Foundation",
     "Win32_Graphics_Gdi",
+    "Win32_UI_Shell_Common",
 ] }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,11 @@ core-graphics = "0.23"
 [target.'cfg(target_os = "windows")'.dependencies]
 fxhash = "0.2"
 widestring = "1.0"
-windows = { version = "0.52", features = [
+windows = { version = "0.54", features = [
     "Win32_Foundation",
     "Win32_Graphics_Gdi",
     "Win32_UI_Shell_Common",
+    "Win32_UI_HiDpi",
 ] }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["display", "screen", "displayinfo", "display-info"]
 
 [dependencies]
 anyhow = "1.0"
+log = "0.4.21"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-graphics = "0.23"

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -8,15 +8,13 @@ use windows::{
     Win32::{
         Foundation::{BOOL, LPARAM, POINT, RECT, TRUE},
         Graphics::Gdi::{
-            EnumDisplayMonitors, EnumDisplaySettingsExW,
-            GetMonitorInfoW, MonitorFromPoint, DEVMODEW,
-            DEVMODE_DISPLAY_ORIENTATION, EDS_RAWMODE, ENUM_CURRENT_SETTINGS, HDC, HMONITOR,
-            MONITORINFOEXW, MONITOR_DEFAULTTONULL,
+            EnumDisplayMonitors, EnumDisplaySettingsExW, GetMonitorInfoW, MonitorFromPoint,
+            DEVMODEW, DEVMODE_DISPLAY_ORIENTATION, EDS_RAWMODE, ENUM_CURRENT_SETTINGS, HDC,
+            HMONITOR, MONITORINFOEXW, MONITOR_DEFAULTTONULL,
         },
         UI::HiDpi::{GetDpiForMonitor, MDT_EFFECTIVE_DPI},
     },
 };
-
 
 pub type ScreenRawHandle = HMONITOR;
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -102,8 +102,16 @@ fn get_rotation_frequency(sz_device: *const u16) -> Result<(f32, f32)> {
 }
 
 fn get_scale_factor(h_monitor: HMONITOR) -> f32 {
-    let device_scale_factor =
-        unsafe { GetScaleFactorForMonitor(h_monitor).unwrap_or(DEVICE_SCALE_FACTOR(100)) };
+    let device_scale_factor = unsafe {
+        match GetScaleFactorForMonitor(h_monitor) {
+            Ok(scale_factor) => scale_factor,
+            Err(e) => {
+                log::warn!("GetScaleFactorForMonitor failed: {:?}", e);
+                DEVICE_SCALE_FACTOR(100)
+            }
+        }
+    };
+    log::debug!("device_scale_factor: {:?}", device_scale_factor.0);
     device_scale_factor.0 as f32 / 100.0
 }
 


### PR DESCRIPTION
使用 `winit` 的做法解决 scale factor 错误的问题。

问题相关：https://stackoverflow.com/questions/63692872/is-getscalefactorformonitor-winapi-returning-incorrect-scaling-factor