### PR TITLE
windows: +features [gdi]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,14 @@ core-graphics = "0.23"
 [target.'cfg(target_os = "windows")'.dependencies]
 fxhash = "0.2"
 widestring = "1.0"
+
+[target.'cfg(all(target_os = "windows", features = "gdi"))'.dependencies]
+windows = { version = "0.54", features = [
+    "Win32_Foundation",
+    "Win32_Graphics_Gdi",
+] }
+
+[target.'cfg(all(target_os = "windows", not(features = "gdi")))'.dependencies]
 windows = { version = "0.54", features = [
     "Win32_Foundation",
     "Win32_Graphics_Gdi",
@@ -27,6 +35,10 @@ windows = { version = "0.54", features = [
     "Win32_UI_HiDpi",
 ] }
 
+
 [target.'cfg(target_os = "linux")'.dependencies]
 xcb = { version = "1.3", features = ["randr"] }
 smithay-client-toolkit = { version = "0.18.1", default-features = false }
+
+[features]
+gdi = []

--- a/README.md
+++ b/README.md
@@ -56,3 +56,7 @@ ArchLinux:
 ```sh
 pacman -S libxcb libxrandr
 ```
+
+## Minimum supported Windows 2000 Professional/Server
+
+Using features `gdi`.


### PR DESCRIPTION
Minimum supported Windows 2000 Professional/Server

> test

```shell
D:\>display_info
GetDpiForMonitor 96
GetDpiForMonitor 96
display_info DisplayInfo { name: "\\\\.\\DISPLAY1", id: 2776250164, raw_handle: HMONITOR(65537), x: 0, y: 0, width: 1024, height: 768, rotation: 0.0, scale_factor: 1.0, frequency: 60.0, is_primary: true }
display_info DisplayInfo { name: "\\\\.\\DISPLAY2", id: 1685731124, raw_handle: HMONITOR(65539), x: 1024, y: 0, width: 1093, height: 614, rotation: 0.0, scale_factor: 1.0, frequency: 60.0, is_primary: false }
GetDpiForMonitor 96
display_info DisplayInfo { name: "\\\\.\\DISPLAY1", id: 2776250164, raw_handle: HMONITOR(65537), x: 0, y: 0, width: 1024, height: 768, rotation: 0.0, scale_factor: 1.0, frequency: 60.0, is_primary: true }
????: 2.6022ms

D:\>display_info_gdi
GetDeviceCaps 96
GetDeviceCaps 96
display_info DisplayInfo { name: "\\\\.\\DISPLAY1", id: 2776250164, raw_handle: HMONITOR(65537), x: 0, y: 0, width: 1024, height: 768, rotation: 0.0, scale_factor: 1.0, frequency: 60.0, is_primary: true }
display_info DisplayInfo { name: "\\\\.\\DISPLAY2", id: 1685731124, raw_handle: HMONITOR(65539), x: 1024, y: 0, width: 1093, height: 614, rotation: 0.0, scale_factor: 1.0, frequency: 60.0, is_primary: false }
GetDeviceCaps 96
display_info DisplayInfo { name: "\\\\.\\DISPLAY1", id: 2776250164, raw_handle: HMONITOR(65537), x: 0, y: 0, width: 1024, height: 768, rotation: 0.0, scale_factor: 1.0, frequency: 60.0, is_primary: true }
????: 1.5353ms
```